### PR TITLE
Hotfix/raquel

### DIFF
--- a/Urenregistratie Applicatie/Urenregistratie Applicatie/Views/MainPage.xaml
+++ b/Urenregistratie Applicatie/Urenregistratie Applicatie/Views/MainPage.xaml
@@ -11,19 +11,16 @@
         <Grid Grid.Row="0"
               Style="{StaticResource HeaderGridStyle}">
 
-            <!-- hamburger button -->
-            <Button Grid.Column="0"
-                    Text="☰"
-                    Style="{StaticResource HeaderIconButtonStyle}" />
 
             <!-- home button -->
-            <Button Grid.Column="1"
+            <Button Grid.Column="0"
                     Text="⌂"
                     Style="{StaticResource HeaderIconButtonStyle}"
                     Clicked="OnMainMenuClicked" />
 
             <!-- Title Label -->
-            <Label Grid.Column="2"
+            <Label x:Name="HeaderTitle"
+                   Grid.Column="2"
                    Text="Urenregistratie"
                    Style="{StaticResource HeaderTitleLabelStyle}" />
         </Grid>

--- a/Urenregistratie Applicatie/Urenregistratie Applicatie/Views/MainPage.xaml.cs
+++ b/Urenregistratie Applicatie/Urenregistratie Applicatie/Views/MainPage.xaml.cs
@@ -23,6 +23,8 @@ public partial class MainPage : ContentPage
     {
         
         SubPage.Content = _defaultContent;
+        HeaderTitle.Text = "Urenregistratie";
+        this.Title = "MijnUren - Hoofdscherm";
 
     }
 
@@ -31,6 +33,8 @@ public partial class MainPage : ContentPage
     {
         
         SubPage.Content = new Page1();
+        HeaderTitle.Text = "Page 1";
+        this.Title = "MijnUren - Page 1";
     }
 
     //Pagina 2 knop
@@ -38,11 +42,15 @@ public partial class MainPage : ContentPage
     {
         
         SubPage.Content = new Page2();
+        HeaderTitle.Text = "Page 2";
+        this.Title = "MijnUren - Page 2";
     }
     //Pagina 3 knop
     private void OnPage3Clicked(object sender, EventArgs e)
     {
         
         SubPage.Content = new Page3();
+        HeaderTitle.Text = "Page 3";
+        this.Title = "MijnUren - Page 3";
     }
 }


### PR DESCRIPTION
 **Sidebar altijd zichtbaar gemaakt en inklapbare menu knop verwijderd**

**Wijzigingen:**
- Sidebar nu standaard zichtbaar op elke pagina
- Alle code die het menu automatisch verstopte verwijderd
- Ongebruikte menu-knop eventhandler (OnMenuButtonClicked) verwijderd uit XAML
- Navigatie aangepast zodat enkel de content wisselt

**Reden:**
- De sidebar moet op elke pagina open blijven voor een consistente gebruikerservaring.

**Extra:**
Dynamische koptekst en titel toegevoegd
- Koptekst toegevoegd om met de pagina mee te veranderen
- Titel toegevoegd om met de pagina mee te veranderen
- Reset toegevoegd bij het indrukken van de homeknop