### PR TITLE
Gebruikersbeheer toegevoegd

### DIFF
--- a/Urenregistratie Applicatie/Urenregistratie Applicatie/Models/UserAccounts.cs
+++ b/Urenregistratie Applicatie/Urenregistratie Applicatie/Models/UserAccounts.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Urenregistratie_Applicatie.Models
+{
+    public class UserAccount
+    {
+        public string Id { get; init; } = string.Empty;
+
+        public string FirstName { get; init; } = string.Empty;
+
+        public string LastName { get; init; } = string.Empty;
+
+        public string Email { get; init; } = string.Empty;
+
+        public string Role { get; init; } = string.Empty;
+    }
+}

--- a/Urenregistratie Applicatie/Urenregistratie Applicatie/Resources/Styles/MyStyles.xaml
+++ b/Urenregistratie Applicatie/Urenregistratie Applicatie/Resources/Styles/MyStyles.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
 
@@ -45,5 +45,56 @@
     <Style x:Key="SubPageWelcomeLabelStyle" TargetType="Label">
         <Setter Property="FontSize" Value="18" />
     </Style>
+
+    <!-- PAGE3: titel bovenaan -->
+    <Style x:Key="UserOverviewTitleLabelStyle" TargetType="Label">
+        <Setter Property="FontSize" Value="22" />
+        <Setter Property="FontAttributes" Value="Bold" />
+    </Style>
+
+    <!-- PAGE3: beschrijving onder titel -->
+    <Style x:Key="UserOverviewDescriptionLabelStyle" TargetType="Label">
+        <Setter Property="TextColor" Value="Gray" />
+    </Style>
+
+    <!-- PAGE3: statuslabel onder de zoekbalk -->
+    <Style x:Key="StatusLabelStyle" TargetType="Label">
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="TextColor" Value="Gray" />
+    </Style>
+
+    <!-- PAGE3: foutmeldingstekst -->
+    <Style x:Key="ErrorLabelStyle" TargetType="Label">
+        <Setter Property="TextColor" Value="DarkRed" />
+        <Setter Property="FontAttributes" Value="Bold" />
+    </Style>
+
+    <!-- PAGE3: lege-staat tekst in CollectionView -->
+    <Style x:Key="EmptyStateLabelStyle" TargetType="Label">
+        <Setter Property="TextColor" Value="Gray" />
+        <Setter Property="HorizontalOptions" Value="Center" />
+        <Setter Property="VerticalOptions" Value="Center" />
+    </Style>
+
+    <!-- PAGE3: access denied kaart -->
+    <Style x:Key="AccessDeniedFrameStyle" TargetType="Frame">
+        <Setter Property="BorderColor" Value="DarkRed" />
+        <Setter Property="BackgroundColor" Value="MistyRose" />
+        <Setter Property="Padding" Value="16" />
+    </Style>
+
+    <Style x:Key="AccessDeniedLabelStyle" TargetType="Label">
+        <Setter Property="TextColor" Value="DarkRed" />
+        <Setter Property="FontAttributes" Value="Bold" />
+    </Style>
+
+    <!-- PAGE3: kolomkop-knoppen in de gebruikerslijst -->
+    <Style x:Key="UserListHeaderButtonStyle" TargetType="Button">
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="HorizontalOptions" Value="Start" />
+        <Setter Property="BackgroundColor" Value="Transparent" />
+        <Setter Property="TextColor" Value="{StaticResource Primary}" />
+    </Style>
+
 
 </ResourceDictionary>

--- a/Urenregistratie Applicatie/Urenregistratie Applicatie/Services/UserService.cs
+++ b/Urenregistratie Applicatie/Urenregistratie Applicatie/Services/UserService.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Urenregistratie_Applicatie.Models;
+
+namespace Urenregistratie_Applicatie.Services;
+
+public class UserService
+{
+    // Voorbeeld gebruikersgegevens (mock data)
+    private readonly List<UserAccount> _seedUsers = new()
+    {
+        new UserAccount
+        {
+            Id = "#4",
+            FirstName = "Naam1",
+            LastName = "Achternaam1",
+            Email = "test1@hotmail.nl",
+            Role = "Rol",
+        },
+        new UserAccount
+        {
+            Id = "#2",
+            FirstName = "Naam2",
+            LastName = "Achternaam2",
+            Email = "test2@hotmail.nl",
+            Role = "Rol",
+        },
+        new UserAccount
+        {
+            Id = "#3",
+            FirstName = "Naam3",
+            LastName = "Achternaam3",
+            Email = "test3@hotmail.nl",
+            Role = "Rol",
+        },
+    };
+
+    // Haalt testgebruikers op uit een lokale mock lijst en doet alsof het van een server komt door een korte vertraging toe te voegen.
+    public async Task<IReadOnlyList<UserAccount>> GetUsersAsync(bool simulateFailure = false)
+    {
+        await Task.Delay(250);
+
+        return _seedUsers
+            .Select(user => new UserAccount
+            {
+                Id = user.Id,
+                FirstName = user.FirstName,
+                LastName = user.LastName,
+                Email = user.Email,
+                Role = user.Role,
+            })
+            .ToList();
+    }
+}

--- a/Urenregistratie Applicatie/Urenregistratie Applicatie/Urenregistratie Applicatie.csproj
+++ b/Urenregistratie Applicatie/Urenregistratie Applicatie/Urenregistratie Applicatie.csproj
@@ -63,10 +63,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Folder Include="Models\" />
 	  <Folder Include="Data\" />
 	  <Folder Include="Helpers\" />
-	  <Folder Include="Services\" />
 	  <Folder Include="ViewModels\" />
 	</ItemGroup>
 

--- a/Urenregistratie Applicatie/Urenregistratie Applicatie/Views/MainPage.xaml
+++ b/Urenregistratie Applicatie/Urenregistratie Applicatie/Views/MainPage.xaml
@@ -43,7 +43,7 @@
                 <Button Text="Page 2"
                         Clicked="OnPage2Clicked" />
 
-                <Button Text="Page 3"
+                <Button Text="Gebruikers"
                         Clicked="OnPage3Clicked" />
 
             </VerticalStackLayout>

--- a/Urenregistratie Applicatie/Urenregistratie Applicatie/Views/MainPage.xaml.cs
+++ b/Urenregistratie Applicatie/Urenregistratie Applicatie/Views/MainPage.xaml.cs
@@ -43,14 +43,14 @@ public partial class MainPage : ContentPage
         
         SubPage.Content = new Page2();
         HeaderTitle.Text = "Page 2";
-        this.Title = "MijnUren - Page 2";
+        this.Title = "Urenoverzicht - Page 2";
     }
     //Pagina 3 knop
     private void OnPage3Clicked(object sender, EventArgs e)
     {
         
         SubPage.Content = new Page3();
-        HeaderTitle.Text = "Page 3";
-        this.Title = "MijnUren - Page 3";
+        HeaderTitle.Text = "Gebruikersoverzict";
+        this.Title = "Gebruikers";
     }
 }

--- a/Urenregistratie Applicatie/Urenregistratie Applicatie/Views/Page3.xaml
+++ b/Urenregistratie Applicatie/Urenregistratie Applicatie/Views/Page3.xaml
@@ -1,11 +1,145 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Urenregistratie_Applicatie.Views.Page3">
-    <VerticalStackLayout>
-        <Label 
-            Text="Dit is pagina 3"
-            VerticalOptions="Center" 
-            HorizontalOptions="Center" />
+             x:Class="Urenregistratie_Applicatie.Views.Page3"
+             Loaded="OnLoaded">
+
+    <VerticalStackLayout Padding="20" Spacing="12">
+
+        <!-- Titel + beschrijving -->
+        <Label Text="Gebruikersoverzicht"
+               Style="{StaticResource UserOverviewTitleLabelStyle}" />
+
+        <Label Text="Als administratiemedewerker kun je hier alle accounts beheren en controleren."
+               Style="{StaticResource UserOverviewDescriptionLabelStyle}" />
+
+        <!-- Access denied-kaart voor niet-admins -->
+        <Frame x:Name="AccessDeniedCard"
+               IsVisible="False"
+               Style="{StaticResource AccessDeniedFrameStyle}">
+            <Label Text="Alleen admins hebben toegang tot deze pagina."
+                   Style="{StaticResource AccessDeniedLabelStyle}" />
+        </Frame>
+
+        <!-- Admin-inhoud (alleen zichtbaar voor admins) -->
+        <VerticalStackLayout x:Name="AdminContent"
+                             Spacing="12"
+                             IsVisible="False">
+
+            <!-- Titel + knoppen boven tabel -->
+            <Grid ColumnDefinitions="*,Auto"
+                  VerticalOptions="Center">
+                <HorizontalStackLayout Spacing="8">
+                    <Button Text="Gebruiker Toevoegen"
+                            Clicked="OnAddUsersClicked"
+                             />
+                </HorizontalStackLayout>
+            </Grid>
+
+            <!-- Zoekbalk -->
+            <SearchBar x:Name="UserSearchBar"
+                       Placeholder="Zoek op naam of e-mail"
+                       TextChanged="OnSearchTextChanged" />
+
+            <!-- Tabel met gebruikers -->
+            <Frame Padding="0">
+                <Grid RowDefinitions="Auto,*">
+
+                    <!-- Header -->
+                    <Grid ColumnDefinitions="2*,2*,3*,1.5*,2*,1*,1*"
+                          Padding="12"
+                          BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}">
+
+                        <Button x:Name="FirstNameHeader"
+                                Grid.Column="0"
+                                Text="Voornaam"
+                                Clicked="OnSortByFirstName"
+                                Style="{StaticResource UserListHeaderButtonStyle}" />
+
+                        <Button x:Name="LastNameHeader"
+                                Grid.Column="1"
+                                Text="Achternaam"
+                                Clicked="OnSortByLastName"
+                                Style="{StaticResource UserListHeaderButtonStyle}" />
+
+                        <Button x:Name="EmailHeader"
+                                Grid.Column="2"
+                                Text="E-mail"
+                                Clicked="OnSortByEmail"
+                                Style="{StaticResource UserListHeaderButtonStyle}" />
+
+                        <Button x:Name="RoleHeader"
+                                Grid.Column="3"
+                                Text="Rol"
+                                Clicked="OnSortByRole"
+                                Style="{StaticResource UserListHeaderButtonStyle}" />
+
+                        <Button x:Name="UserIdHeader"
+                                Grid.Column="4"
+                                Text="Gebruikers-ID"
+                                Clicked="OnSortById"
+                                Style="{StaticResource UserListHeaderButtonStyle}" />
+                    </Grid>
+
+                    <!-- Gebruikerslijst -->
+                    <CollectionView x:Name="UsersCollection"
+                                    Grid.Row="1"
+                                    ItemsLayout="VerticalList"
+                                    SelectionMode="None"
+                                    ItemsSource="{Binding}">
+                        <CollectionView.EmptyView>
+                            <Label x:Name="EmptyStateLabel"
+                                   Text="Geen gebruikers gevonden"
+                                   Style="{StaticResource EmptyStateLabelStyle}" />
+                        </CollectionView.EmptyView>
+
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate>
+                                <Grid ColumnDefinitions="2*,2*,3*,1.5*,2*,0.5*,0.5*"
+                                      Padding="12"
+                                      ColumnSpacing="8"
+                                      BackgroundColor="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}">
+
+                                    <Label Grid.Column="0"
+                                           Text="{Binding FirstName}" />
+                                    <Label Grid.Column="1"
+                                           Text="{Binding LastName}" />
+                                    <Label Grid.Column="2"
+                                           Text="{Binding Email}" />
+                                    <Label Grid.Column="3"
+                                           Text="{Binding Role}" />
+                                    <Label Grid.Column="4"
+                                           Text="{Binding Id}" />
+                                    <!-- Gebruiker verwijderen knop -->
+                                    <Button
+                                      Grid.Column="5"
+                                      Clicked="OnDeleteUsersClicked"
+                                      Text="🗑"
+                                      FontSize="18"
+                                      BackgroundColor="Purple"
+                                      HorizontalOptions="End"
+                                      VerticalOptions="Center"
+                                      Padding="0"
+                                      Margin="0,0,0,0" />
+                                    <!-- gebruiker bewerken knop -->
+                                    <Button
+                                      Grid.Column="6"
+                                      Clicked="OnEditUsersClicked"
+                                      Text="✎"
+                                      FontSize="18"
+                                      BackgroundColor="Purple"
+                                      HorizontalOptions="End"
+                                      VerticalOptions="Center"
+                                      Padding="0"
+                                      Margin="0,0,0,0" />
+                                </Grid>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+
+                </Grid>
+            </Frame>
+        </VerticalStackLayout>
+
     </VerticalStackLayout>
 </ContentView>

--- a/Urenregistratie Applicatie/Urenregistratie Applicatie/Views/Page3.xaml.cs
+++ b/Urenregistratie Applicatie/Urenregistratie Applicatie/Views/Page3.xaml.cs
@@ -1,9 +1,206 @@
+﻿using System.Collections.ObjectModel;
+using Microsoft.Extensions.Logging;
+using Urenregistratie_Applicatie.Models;
+using Urenregistratie_Applicatie.Services;
+
 namespace Urenregistratie_Applicatie.Views;
+
 
 public partial class Page3 : ContentView
 {
-	public Page3()
-	{
-		InitializeComponent();
-	}
+    // Ophalen uit opslag voor alle gebruikers  en wat zichtbaar is op het scherm
+    private readonly ObservableCollection<UserAccount> _allUsers = new();
+    private readonly ObservableCollection<UserAccount> _visibleUsers = new();
+
+    // Uit service mock-data
+    private readonly UserService _userService = new();
+
+    // Zoeken/sorteer instellingen
+    private string _searchTerm = string.Empty;
+    private string _sortColumn = nameof(UserAccount.Id);
+    private bool _sortAscending = true;
+
+    // Admin toegangscontrole, true = toegang tot de scherm, false = geen toegang
+    private bool _isAdminUser = true;
+
+    public Page3()
+    {
+        InitializeComponent();
+
+        // UI lijst koppelen aan zichtbare lijst
+        UsersCollection.ItemsSource = _visibleUsers;
+    }
+
+    // Bij laden van de pagina: gebruikersscherm tonen en users laden
+    private async void OnLoaded(object? sender, EventArgs e)
+    {
+        await InitializeAsync();
+    }
+
+    private async Task InitializeAsync()
+    {
+        AdminContent.IsVisible = _isAdminUser;
+        AccessDeniedCard.IsVisible = !_isAdminUser;
+
+        if (!_isAdminUser)
+            return;
+
+        await LoadUsersAsync();
+    }
+
+    // Gebruikers uit service ophalen en in UI zetten
+    private async Task LoadUsersAsync(bool simulateFailure = false)
+    {
+        var users = await _userService.GetUsersAsync(simulateFailure);
+
+        _allUsers.Clear();
+        foreach (var user in users)
+            _allUsers.Add(user);
+
+        ApplyFiltersAndSorting();
+    }
+
+    // Word aangeroepen zodra de tekst in de zoekbalk veranderd/ingevuld word en past filter meteen toe.
+    private void OnSearchTextChanged(object sender, TextChangedEventArgs e)
+    {
+        _searchTerm = e.NewTextValue ?? string.Empty;
+        ApplyFiltersAndSorting();
+    }
+
+
+    // functie Zoeken en sorteren, de lijst met gebruikers filteren op basis van de zoekterm
+    private void ApplyFiltersAndSorting()
+    {
+        if (!_isAdminUser)
+            return;
+
+        IEnumerable<UserAccount> filtered = _allUsers;
+
+        if (!string.IsNullOrWhiteSpace(_searchTerm))
+            filtered = filtered.Where(MatchesSearchTerm);
+
+        filtered = SortUsers(filtered);
+
+        UpdateVisibleUsers(filtered.ToList());
+        EmptyStateLabel.IsVisible = !_visibleUsers.Any();
+    }
+
+    // Zoeken op voornaam, achternaam of e-mail
+    private bool MatchesSearchTerm(UserAccount user)
+    {
+        var term = _searchTerm.Trim();
+        if (string.IsNullOrWhiteSpace(term))
+            return true;
+
+        return user.FirstName.Contains(term, StringComparison.OrdinalIgnoreCase)
+            || user.LastName.Contains(term, StringComparison.OrdinalIgnoreCase)
+            || user.Email.Contains(term, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // De sorteer functie 
+    private void ApplySorting(string sortColumn)
+    {
+        if (_sortColumn == sortColumn)
+        {
+            _sortAscending = !_sortAscending;
+        }
+        else
+        {
+            _sortColumn = sortColumn;
+            _sortAscending = true;
+        }
+
+        UpdateSortHeaderLabels();
+        ApplyFiltersAndSorting();
+    }
+
+
+    // Event-handlers die de sortering binnen de columns regelen
+    private void OnSortByFirstName(object sender, EventArgs e) => ApplySorting(nameof(UserAccount.FirstName));
+    private void OnSortByLastName(object sender, EventArgs e) => ApplySorting(nameof(UserAccount.LastName));
+    private void OnSortByEmail(object sender, EventArgs e) => ApplySorting(nameof(UserAccount.Email));
+    private void OnSortByRole(object sender, EventArgs e) => ApplySorting(nameof(UserAccount.Role));
+    private void OnSortById(object sender, EventArgs e) => ApplySorting(nameof(UserAccount.Id));
+
+
+    // Sorteer op basis van gekozen kolom en richting
+    private IEnumerable<UserAccount> SortUsers(IEnumerable<UserAccount> users)
+    {
+        if (_sortColumn == nameof(UserAccount.FirstName))
+        {
+            return _sortAscending
+                ? users.OrderBy(u => u.FirstName)
+                : users.OrderByDescending(u => u.FirstName);
+        }
+
+        if (_sortColumn == nameof(UserAccount.LastName))
+        {
+            return _sortAscending
+                ? users.OrderBy(u => u.LastName)
+                : users.OrderByDescending(u => u.LastName);
+        }
+
+        if (_sortColumn == nameof(UserAccount.Email))
+        {
+            return _sortAscending
+                ? users.OrderBy(u => u.Email)
+                : users.OrderByDescending(u => u.Email);
+        }
+
+        if (_sortColumn == nameof(UserAccount.Role))
+        {
+            return _sortAscending
+                ? users.OrderBy(u => u.Role)
+                : users.OrderByDescending(u => u.Role);
+        }
+
+        if (_sortColumn == nameof(UserAccount.Id))
+        {
+            return _sortAscending
+                ? users.OrderBy(u => u.Id)
+                : users.OrderByDescending(u => u.Id);
+        }
+
+        return _sortAscending
+            ? users.OrderBy(u => u.Id)
+            : users.OrderByDescending(u => u.Id);
+    }
+
+
+    // Zorgt ervoor dat de zichtbare lijst ook visueel wordt bijgewerkt (dus niet alleen in geheugen)
+    private void UpdateVisibleUsers(IReadOnlyCollection<UserAccount> users)
+    {
+        _visibleUsers.Clear();
+        foreach (var user in users)
+            _visibleUsers.Add(user);
+    }
+
+    // Deze functie zet bij elke kolomheader de juiste tekst en plaatst een sorteer pijltje (▲ of ▼) bij de kolom waarop op dat moment gesorteerd wordt.
+    private void UpdateSortHeaderLabels()
+    {
+        FirstNameHeader.Text = BuildSortLabel("Voornaam", nameof(UserAccount.FirstName));
+        LastNameHeader.Text = BuildSortLabel("Achternaam", nameof(UserAccount.LastName));
+        EmailHeader.Text = BuildSortLabel("E-mail", nameof(UserAccount.Email));
+        RoleHeader.Text = BuildSortLabel("Rol", nameof(UserAccount.Role));
+        UserIdHeader.Text = BuildSortLabel("Gebruikers-ID", nameof(UserAccount.Id));
+    }
+
+    //Deze functie voegt een sorteer-pijltje (▲ of ▼) toe aan de kolomnaam als die kolom op dat moment gebruikt wordt om te sorteren.
+    private string BuildSortLabel(string kolomNaam, string kolomPropertyNaam)
+    {
+        if (_sortColumn != kolomPropertyNaam)
+            return kolomNaam;
+
+        string pijltje = _sortAscending ? "▲" : "▼";
+
+        return kolomNaam + " " + pijltje;
+    }
+
+    // Tijdelijke knoppen voor gebruikers toevoegen, wijzigen en gebruikers verwijderen.
+    private async void OnAddUsersClicked(object sender, EventArgs e) =>
+        await Application.Current.MainPage.DisplayAlert("Melding", "Tijdelijke actie toevoegen gebruiker", "Kaas");
+    private async void OnEditUsersClicked(object sender, EventArgs e) =>
+        await Application.Current.MainPage.DisplayAlert("Melding", "Tijdelijke actie gebruiker wijzingen", "Pepernoten");
+    private async void OnDeleteUsersClicked(object sender, EventArgs e) =>
+        await Application.Current.MainPage.DisplayAlert("Melding", "Tijdelijke knop voor verwijderen gebruiker", "Eieren");
 }


### PR DESCRIPTION
Gebruikersbeheer toegevoegd
In deze update heb ik een gebruikersbeheer scherm gemaakt (Page3) waar een
admin gebruikers kan bekijken, zoeken en sorteren. De data komt nu nog uit
een UserService die werkt met mock/test gebruikers, omdat er nog geen
database of API is aangesloten.

Ook heb ik een UserAccount model toegevoegd voor het opslaan van
gebruikersgegevens zoals Id, Voornaam, Achternaam, E-mail en Rol. Dit model
wordt gebruikt om gebruikers overal op dezelfde manier weer te geven.

De belangrijkste functionaliteiten:
- Gebruikers worden automatisch geladen bij het openen van het scherm.
- Zoeken werkt direct tijdens het typen (voornaam, achternaam, e-mail).
- Sorteren werkt per kolom met een visueel pijltje (▲ / ▼), zodat je altijd
  ziet hoe en waarop gesorteerd wordt.
- De UI werkt automatisch bij wanneer er gesorteerd of gezocht wordt, omdat
  er gebruik wordt gemaakt van ObservableCollection.
- Admin controle zorgt dat alleen admins toegang hebben tot het scherm, andere
  gebruikers zien een nette melding dat toegang geweigerd is.

Extra:
- Knoppen voor toevoegen, wijzigen en verwijderen van gebruikers zijn alvast
  toegevoegd als tijdelijke placeholders. Deze tonen nu alleen een melding,
  maar zijn klaar voor uitbreiding met echte beheeracties.

Deze update vormt de basis van het gebruikersbeheer in de applicatie. Later
kan de mock data eenvoudig vervangen worden door echte data via een API of
database.